### PR TITLE
macOS version re-written with objc-runtime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ else ifeq ($(shell uname -s),Linux)
 	TRAY_CFLAGS := -DTRAY_APPINDICATOR=1 $(shell pkg-config --cflags appindicator3-0.1)
 	TRAY_LDFLAGS := $(shell pkg-config --libs appindicator3-0.1)
 else ifeq ($(shell uname -s),Darwin)
-	TRAY_CFLAGS := -DTRAY_APPKIT=1 -x objective-c
+	TRAY_CFLAGS := -DTRAY_APPKIT=1
 	TRAY_LDFLAGS := -framework Cocoa
 endif
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ array must have text field set to NULL.
 * [x] Checked/unchecked menu items
 * [x] Nested menus
 * [ ] Icons for menu items
-* [ ] Rewrite ObjC code in C using ObjC Runtime (now ObjC code breaks many linters and static analyzers)
+* [x] Rewrite ObjC code in C using ObjC Runtime (now ObjC code breaks many linters and static analyzers)
 * [ ] Call GTK code using dlopen/dlsym (to make binaries run safely if Gtk libraries are not available)
 
 ## License


### PR DESCRIPTION
All Objective-C has been replaced with C using ObjC Runtime.  The section was completely re-written with the goal of not needing to include the Cocoa headers as some compilers/static analyzers/linters mistake the headers for errors.

A fortunate side-effect of this is the '-x objective-c' flag is no longer needed to compile.