### PR TITLE
[win] close menu if user clicks outside

### DIFF
--- a/tray.h
+++ b/tray.h
@@ -230,6 +230,7 @@ static LRESULT CALLBACK _tray_wnd_proc(HWND hwnd, UINT msg, WPARAM wparam,
     if (lparam == WM_LBUTTONUP || lparam == WM_RBUTTONUP) {
       POINT p;
       GetCursorPos(&p);
+      SetForegroundWindow(hwnd);
       WORD cmd = TrackPopupMenu(hmenu, TPM_LEFTALIGN | TPM_RIGHTBUTTON |
                                            TPM_RETURNCMD | TPM_NONOTIFY,
                                 p.x, p.y, 0, hwnd, NULL);


### PR DESCRIPTION
See also here ("Important: If you implement a context menu, it's vital that you set your window to the foreground before calling TrackPopupMenu to ensure the menu closes properly."):
https://www.codeproject.com/Articles/4768/Basic-use-of-Shell-NotifyIcon-in-Win32