### PR TITLE
Add support for tooltip

### DIFF
--- a/example.c
+++ b/example.c
@@ -56,29 +56,32 @@ static void submenu_cb(struct tray_menu *item) {
 // Test tray init
 static struct tray tray = {
     .icon = TRAY_ICON1,
+#if TRAY_WINAPI
+    .tooltip = "Tray",
+#endif
     .menu =
-        (struct tray_menu[]){
+        (struct tray_menu[]) {
             {.text = "Hello", .cb = hello_cb},
             {.text = "Checked", .checked = 1, .cb = toggle_cb},
             {.text = "Disabled", .disabled = 1},
             {.text = "-"},
             {.text = "SubMenu",
              .submenu =
-                 (struct tray_menu[]){
+                 (struct tray_menu[]) {
                      {.text = "FIRST", .checked = 1, .cb = submenu_cb},
                      {.text = "SECOND",
                       .submenu =
-                          (struct tray_menu[]){
+                          (struct tray_menu[]) {
                               {.text = "THIRD",
                                .submenu =
-                                   (struct tray_menu[]){
+                                   (struct tray_menu[]) {
                                        {.text = "7", .cb = submenu_cb},
                                        {.text = "-"},
                                        {.text = "8", .cb = submenu_cb},
                                        {.text = NULL}}},
                               {.text = "FOUR",
                                .submenu =
-                                   (struct tray_menu[]){
+                                   (struct tray_menu[]) {
                                        {.text = "5", .cb = submenu_cb},
                                        {.text = "6", .cb = submenu_cb},
                                        {.text = NULL}}},

--- a/tray.h
+++ b/tray.h
@@ -5,6 +5,7 @@ struct tray_menu;
 
 struct tray {
   char *icon;
+  char *tooltip;
   struct tray_menu *menu;
 };
 
@@ -308,8 +309,9 @@ static int tray_init(struct tray *tray) {
   nid.cbSize = sizeof(NOTIFYICONDATA);
   nid.hWnd = hwnd;
   nid.uID = 0;
-  nid.uFlags = NIF_ICON | NIF_MESSAGE;
+  nid.uFlags = NIF_ICON | NIF_MESSAGE | NIF_TIP;
   nid.uCallbackMessage = WM_TRAY_CALLBACK_MESSAGE;
+  strncpy(nid.szTip, tray->tooltip, sizeof(nid.szTip));
   Shell_NotifyIcon(NIM_ADD, &nid);
 
   tray_update(tray);

--- a/tray.h
+++ b/tray.h
@@ -311,10 +311,6 @@ static int tray_init(struct tray *tray) {
   nid.uID = 0;
   nid.uFlags = NIF_ICON | NIF_MESSAGE;
   nid.uCallbackMessage = WM_TRAY_CALLBACK_MESSAGE;
-  if(tray->tooltip != 0 && strlen(tray->tooltip) > 0) {
-    strncpy(nid.szTip, tray->tooltip, sizeof(nid.szTip));
-    nid.uFlags |= NIF_TIP;
-  }
   Shell_NotifyIcon(NIM_ADD, &nid);
 
   tray_update(tray);
@@ -347,6 +343,10 @@ static void tray_update(struct tray *tray) {
     DestroyIcon(nid.hIcon);
   }
   nid.hIcon = icon;
+  if(tray->tooltip != 0 && strlen(tray->tooltip) > 0) {
+    strncpy(nid.szTip, tray->tooltip, sizeof(nid.szTip));
+    nid.uFlags |= NIF_TIP;
+  }
   Shell_NotifyIcon(NIM_MODIFY, &nid);
 
   if (prevmenu != NULL) {

--- a/tray.h
+++ b/tray.h
@@ -309,9 +309,12 @@ static int tray_init(struct tray *tray) {
   nid.cbSize = sizeof(NOTIFYICONDATA);
   nid.hWnd = hwnd;
   nid.uID = 0;
-  nid.uFlags = NIF_ICON | NIF_MESSAGE | NIF_TIP;
+  nid.uFlags = NIF_ICON | NIF_MESSAGE;
   nid.uCallbackMessage = WM_TRAY_CALLBACK_MESSAGE;
-  strncpy(nid.szTip, tray->tooltip, sizeof(nid.szTip));
+  if(tray->tooltip != 0 && strlen(tray->tooltip) > 0) {
+    strncpy(nid.szTip, tray->tooltip, sizeof(nid.szTip));
+    nid.uFlags |= NIF_TIP;
+  }
   Shell_NotifyIcon(NIM_ADD, &nid);
 
   tray_update(tray);


### PR DESCRIPTION
At least on Windows, it is standard for tray icons to have tooltips. Hence, I added an option to set one. (If the user doesn't want that, he can set NULL or an empty string)

I am only able to implement the Windows part though (I realize the check for TRAY_WINAPI isn't really necessary because on the other platforms it simply wouldn't do anything... I merely put it there for emphasis) and don't know what the common behavior on Linux distros and macOS is.